### PR TITLE
Send video error events to parent

### DIFF
--- a/player/view.js
+++ b/player/view.js
@@ -69,6 +69,13 @@ AchSoPlayer.prototype.startView = function(rootElement, data) {
         player.stopOnEnd();
     });
 
+    this.elements.video.addEventListener("error", function(e) {
+      window.parent.postMessage(JSON.stringify({
+        data: {id: data.id},
+        type: 'video:error'
+      }), "*");
+    });
+
     // @BrowserHack(Firefox): Seeking when paused results in black frames
     // sometimes with Firefox so force repaint the video on seek.
     if (/firefox/i.test(navigator.userAgent)) {
@@ -486,4 +493,3 @@ AchSoPlayer.prototype.updateUndoButtonsView = function(undo, redo) {
         this.elements.redoButton.classList.add("acp-disabled");
     }
 };
-

--- a/player/view.js
+++ b/player/view.js
@@ -38,6 +38,11 @@ AchSoPlayer.prototype.startView = function(rootElement, data) {
         var height = player.elements.video.videoHeight;
         player.setVideoSize(width, height);
         player.activate();
+
+        window.parent.postMessage(JSON.stringify({
+          data: {id: data.id},
+          type: 'video:loadedmetadata'
+        }), "*");
     });
 
     this.elements.video.addEventListener("durationchange", function() {


### PR DESCRIPTION
If a video error event occurs, send it to the parent using postMessage.